### PR TITLE
[3337] add an option to log to stdout

### DIFF
--- a/recipes/attributes.rb
+++ b/recipes/attributes.rb
@@ -54,8 +54,12 @@ node.default['aerospike']['config']['mod-lua']['user-path'] = ::File.join(node['
 node.default['aerospike']['config']['mod-lua']['system-path'] = ::File.join(node['aerospike']['work_dir'], 'sys', 'udf', 'lua')
 
 # logging ()
-config_log_file = "file #{node['aerospike']['log_file']}"
-node.default['aerospike']['config']['logging'][config_log_file]['context'] = 'any info'
+if node['aerospike']['log_to_stdout']
+  node.default['aerospike']['config']['logging']['console']['context'] = 'any info'
+else
+  config_log_file = "file #{node['aerospike']['log_file']}"
+  node.default['aerospike']['config']['logging'][config_log_file]['context'] = 'any info'
+end
 
 # enable test namespace by default
 if node['aerospike']['enable_test_namespace']


### PR DESCRIPTION
[Trello card](https://trello.com/c/Mt84kHUh/3337-reconfigure-aerospike-to-log-to-stdout)

This PR adds `log_to_stdout` flag which can be used to enable logging to `stdout` according to https://www.aerospike.com/docs/operations/configure/log/.